### PR TITLE
bug修复-现在可以重复训练了

### DIFF
--- a/judge.py
+++ b/judge.py
@@ -60,7 +60,7 @@ def action_judge(ctx: Context):
 
     # boss掉血的情况
     blood_change = ctx.boss_blood - ctx.next_boss_blood
-    if blood_change > 0 and blood_change < 5:  # 伤害不可能太高，太高就是计算出错了
+    if blood_change > 0 and blood_change < 10:  # 伤害不可能太高，太高就是计算出错了
         add_award = 100 * blood_change * ctx.attack_weight * reward_weight
         ctx.reward += add_award  # 鼓励攻击boss
         ctx.attack_weight = min(1, ctx.attack_weight + blood_change)

--- a/judge.py
+++ b/judge.py
@@ -21,40 +21,30 @@ def action_judge(ctx: Context):
     log(f"reward_weight={reward_weight}")
 
     # 自己死亡的情况
-    if ctx.self_blood <= 0 and ctx.next_self_blood <= 0:
+    if ctx.self_blood <= 5 and ctx.next_self_blood <= 0:
         # TODO: boss最后几帧的血量可能已经变成0了，这里需要优化一下，能准确记录boss每局最后的血量
         boss_remain_blood = max(ctx.next_boss_blood, ctx.boss_blood)
 
-        time.sleep(1) # 等一秒再读取一波数据，如果这时候血量空了就是真的完辣
-        ctx.updateNextContext()
-        ctx.updateContext()
+        dead_reward = 50000
+        boss_remain_blood_award = (100 - boss_remain_blood) * (dead_reward / 100)
+        ctx.reward += boss_remain_blood_award
+        ctx.reward -= dead_reward
+        ctx.done, ctx.stop, ctx.emergence_break = 1, 0, 100
+        ctx.dodge_weight, ctx.attack_weight = 1, 1
 
-        if ctx.self_blood <= 0 and ctx.next_self_blood <= 0:
-            dead_reward = 50000
-            boss_remain_blood_award = (100 - boss_remain_blood) * (dead_reward / 100)
-            ctx.reward += boss_remain_blood_award
-            ctx.reward -= dead_reward
-            ctx.done, ctx.stop, ctx.emergence_break = 1, 0, 100
-            ctx.dodge_weight, ctx.attack_weight = 1, 1
-
-            log(f"吗喽已死亡, 当前状态: done={ctx.done}, stop={ctx.stop}, "
-                f"emergence_break={ctx.emergence_break}, dodge_weight={ctx.dodge_weight}, "
-                f"attack_weight={ctx.attack_weight}")
-            
-            reward_tracker.add_reward(ctx.reward)  # 添加当前奖励
-            reward_tracker.end_episode(boss_remain_blood)  # 每局结束时记录 Boss 血量
-
-            # 每10局保存一次
-            if reward_tracker.episode_num % 10 == 0:
-                reward_tracker.save_overall_data()
-            return ctx
+        log(f"吗喽已死亡, 当前状态: done={ctx.done}, stop={ctx.stop}, "
+            f"emergence_break={ctx.emergence_break}, dodge_weight={ctx.dodge_weight}, "
+            f"attack_weight={ctx.attack_weight}")
         
-        else:
-            log(f"只是被飞扑打到而已，吗喽还很好^_^")
+        reward_tracker.add_reward(ctx.reward)  # 添加当前奖励
+        reward_tracker.end_episode(boss_remain_blood)  # 每局结束时记录 Boss 血量
 
-    elif ctx.boss_blood - ctx.next_boss_blood > 5:
-        log("Boss血量骤减，跳过处理。")
+        # 每10局保存一次
+        if reward_tracker.episode_num % 10 == 0:
+            reward_tracker.save_overall_data()
         return ctx
+
+
 
     # 自己掉血的情况
     blood_change = ctx.self_blood - ctx.next_self_blood

--- a/restart.py
+++ b/restart.py
@@ -156,7 +156,7 @@ def yinhu_restart_V2():
         log('%d秒后复活' % i)
         actions.precise_sleep(1)
 
-    actions.go_forward(2)
+    actions.go_forward(1.5)
     actions.precise_sleep(3) # 必须等一会儿，不然按键会没响应
 
     # 交互

--- a/training.py
+++ b/training.py
@@ -48,6 +48,7 @@ if __name__ == "__main__":
         last_time = time.time()
         target_step = 0
         total_reward = 0
+        ctx.done = 0
 
         while True:
             # reshape station for tf input placeholder

--- a/window.py
+++ b/window.py
@@ -26,7 +26,7 @@ class Bloodwindow(Graywindow):
         super().__init__(sx, sy, ex, ey)
         # 剩余血量的灰度值范围, 即血条白色部分的灰度值
         self.blood_gray_max = 255
-        self.blood_gray_min = 127
+        self.blood_gray_min = 120
 
     def blood_count(self) -> int:
         total_length = self.image.shape[1]  # 血条的总长度是图像的宽度

--- a/window.py
+++ b/window.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import cv2
 import grabscreen
+import numpy as np
 
 class Graywindow(object):
     def __init__(self, sx, sy, ex, ey):
@@ -27,8 +28,24 @@ class Bloodwindow(Graywindow):
         # 剩余血量的灰度值范围, 即血条白色部分的灰度值
         self.blood_gray_max = 255
         self.blood_gray_min = 120
-
     def blood_count(self) -> int:
+        # 直接获取图像中间一行像素
+        middle_row = self.gray[self.gray.shape[0] // 2, :]
+
+        # 使用 np.clip 限制在 blood_gray_min 和 blood_gray_max 之间的值
+        clipped = np.clip(middle_row, self.blood_gray_min, self.blood_gray_max)
+
+        # 计算符合血量区间的像素数量
+        current_health_length = np.count_nonzero(clipped == middle_row)
+
+        # 计算血量百分比
+        total_length = len(middle_row)
+        health_percentage = (current_health_length / total_length) * 100
+
+        return health_percentage
+
+
+    def blood_count2(self) -> int:
         total_length = self.image.shape[1]  # 血条的总长度是图像的宽度
         max_find_cnt = 2
         while max_find_cnt > 0:


### PR DESCRIPTION
1. 挨打的时候  血条有时候亮度值会低于 127 导致血量计算错误 比如这个图 灰度值是123

![debug_frame_95](https://github.com/user-attachments/assets/b9c0f7ba-78e6-4856-89d4-ee7cf5e1bea9)

2. ctx.done  死亡后 你忘记重置了 

3. 关于boss掉血的情况 我看到你 判断超过5% 就是错误 但是我加了双爆的  一棍子下去  10%都正常啊 会不会是 之前图片灰度值 跳跃导致的问题 你纳入进奖励函数来规避了

4. 关于windows.py 要注意现在代码仓库里是我的 窗口小分辨率模式 不是你的全屏模式的坐标值 我们需要想个办法来统一坐标 或者支持 多个坐标配置 这样不用硬编码进文件了
 

