### PR TITLE
feat:add action

### DIFF
--- a/config/actions_config.yaml
+++ b/config/actions_config.yaml
@@ -3,7 +3,7 @@ actions:
   IDLE:
     - ['delay', 0.1 ]
 
-  LIGHT_ATTACK:
+  LIGHT_ATTACK: &LIGHT_ATTACK
     - ['press_mouse', 'left']
     - ['delay', 0.14 ]
     - ['release_mouse', 'left']
@@ -16,10 +16,14 @@ actions:
     - ['delay', 2.53]
   
   DRINK_POTION:
+    - ['press', 'space']
+    - ['delay', 0.16]
+    - ['release', 'space']
+    - ['delay', 0.34]
     - ['press', 'r']
     - ['delay', 0.12]
     - ['release', 'r']
-    - ['delay', 1.37]
+    - ['delay', 1]
   
   DODGE: &DODGE
     - ['press', 'space']
@@ -28,11 +32,28 @@ actions:
     - ['delay', 0.34]
 
   DODGE_TWO: &DODGE_TWO
-    - *DODGE
+    - [ 'press', 'space' ]
+    - [ 'delay', 0.16 ]
+    - [ 'release', 'space' ]
+    - [ 'delay', 0.2 ]
+    - [ 'press', 'space' ]
+    - [ 'delay', 0.16 ]
+    - [ 'release', 'space' ]
+    - [ 'delay', 0.34 ]
 
-  DODGE_THREE: &DODGE_THREE
-    - *DODGE
-    - *DODGE_TWO
+  DODGE_THREE:
+    - [ 'press', 'space' ]
+    - [ 'delay', 0.16 ]
+    - [ 'release', 'space' ]
+    - [ 'delay', 0.2 ]
+    - [ 'press', 'space' ]
+    - [ 'delay', 0.16 ]
+    - [ 'release', 'space' ]
+    - [ 'delay', 0.2 ]
+    - [ 'press', 'space' ]
+    - [ 'delay', 0.16 ]
+    - [ 'release', 'space' ]
+    - [ 'delay', 0.34 ]
 
   ATTACK_DODGE:
     - ['press_mouse', 'left']
@@ -54,11 +75,22 @@ actions:
     - ['release_mouse', 'right']
     - ['delay', 0.96]
 
+  THREE_HIT_COMBO: &THREE_HIT_COMBO
+    - [ 'press_mouse', 'left' ]
+    - [ 'delay', 0.13 ]
+    - [ 'release_mouse', 'left' ]
+    - [ 'delay', 0.3 ]
+    - [ 'press_mouse', 'left' ]
+    - [ 'delay', 0.14 ]
+    - [ 'release_mouse', 'left' ]
+    - [ 'delay', 0.32 ]
+    - *DODGE
+
   FIVE_HIT_COMBO:
     - ['press_mouse', 'left']
     - ['delay', 0.13 ]
     - ['release_mouse', 'left']
-    - ['delay', 0.39]
+    - ['delay', 0.3]
     - ['press_mouse', 'left']
     - ['delay', 0.14 ]
     - ['release_mouse', 'left']
@@ -92,7 +124,7 @@ actions:
     - ['press', '3']
     - ['delay', 0.16]
     - ['release', '3']
-    - ['delay', 1.96]
+    - ['delay', 1.90]
   
   SKILL_4: &SKILL_4
     - ['press', '4']
@@ -100,34 +132,93 @@ actions:
     - ['release', '4']
     - ['delay', 1.19]
 
+  RUN_CHARGE:  &RUN_CHARGE
+    - [ 'delay', 0.16 ]
+    - [ 'press_mouse', 'right' ]
+    - [ 'press', 'shift' ]
+    - [ 'delay', 0.2 ]
+    - [ 'press', 'd' ]
+    - [ 'delay', 1.45 ]
+    - [ 'release', 'd' ]
+    - [ 'press', 'w' ]
+    - [ 'delay', 1.45 ]
+    - [ 'release', 'w' ]
+    - [ 'press', 'a' ]
+    - [ 'delay', 1.45 ]
+    - [ 'release', 'a' ]
+    - [ 'press', 'w' ]
+    - [ 'delay', 1 ]
+    - [ 'release', 'w' ]
+    - [ 'delay', 0.2 ]
+    - [ 'release', 'shift' ]
+    - [ 'release_mouse', 'right' ]
+    - [ 'delay', 3.4 ]
+
   STEALTH_CHARGE:
     - *SKILL_2
-    - ['delay', 0.16]
-    - ['press_mouse', 'right']
-    - ['press', 'shift']
-    - ['delay', 0.2]
-    - ['press', 'd']
-    - ['delay', 2.45]
-    - ['release', 'd']
-    - ['press', 'w']
-    - ['delay', 1.45]
-    - ['release', 'w']
-    - ['press', 'a']
-    - ['delay', 1.45]
-    - ['release', 'a']
-    - ['press', 'w']
-    - ['delay', 0.45]
-    - ['release', 'w']
-    - ['delay', 0.2]
-    - ['release', 'shift']
-    - ['release_mouse', 'right']
-    - ['delay', 3.43]
+    - *RUN_CHARGE
+
+
+  DING_CHARGE:
+    - *SKILL_1
+    - [ 'delay', 0.16 ]
+    - [ 'press_mouse', 'right' ]
+    - [ 'press', 'shift' ]
+    - [ 'delay', 0.2 ]
+    - [ 'press', 'd' ]
+    - [ 'delay', 1.45 ]
+    - [ 'release', 'd' ]
+    - [ 'press', 'w' ]
+    - [ 'delay', 1.45 ]
+    - [ 'release', 'w' ]
+    - [ 'press', 'a' ]
+    - [ 'delay', 1.45 ]
+    - [ 'release', 'a' ]
+    - [ 'press', 'w' ]
+    - [ 'delay', 1 ]
+    - [ 'release', 'w' ]
+    - [ 'delay', 0.2 ]
+    - [ 'release', 'shift' ]
+    - [ 'release_mouse', 'right' ]
+    - [ 'delay', 3.4 ]
+
+  STEALTH_DRINK:
+    - *SKILL_2
+    - [ 'delay', 0.6 ]
+    - [ 'press', 'r' ]
+    - [ 'delay', 0.16 ]
+    - [ 'release', 'r' ]
+    - [ 'delay', 0.8 ]
+    - [ 'press_mouse', 'left' ]
+    - [ 'delay', 0.13 ]
+    - [ 'release_mouse', 'left' ]
+    - [ 'delay', 1.7 ]
+    - [ 'press_mouse', 'left' ]
+    - [ 'delay', 0.13 ]
+    - [ 'release_mouse', 'left' ]
+    - [ 'delay', 0.15 ]
+    - [ 'press_mouse', 'left' ]
+    - [ 'delay', 0.14 ]
+    - [ 'release_mouse', 'left' ]
+    - [ 'delay', 0.15 ]
+    - [ 'press_mouse', 'left' ]
+    - [ 'delay', 0.14 ]
+    - [ 'release_mouse', 'left' ]
+    - [ 'delay', 0.15 ]
+    - [ 'press_mouse', 'left' ]
+    - [ 'delay', 0.14 ]
+    - [ 'release_mouse', 'left' ]
+    - [ 'delay', 0.25 ]
+    - [ 'press', 'space' ]
+    - [ 'delay', 0.16 ]
+    - [ 'release', 'space' ]
+    - [ 'delay', 0.34 ]
 
   FABAO:
     - ['press', 't']
     - ['delay', 0.16]
     - ['release', 't']
-    - ['delay', 1.19]
+    - ['delay', 1.55]
   
   TISHEN:
     - ['press', 'f']
@@ -212,8 +303,18 @@ actions:
     - ['delay', 6]
     - *RUN_FORWARD
 
+  huxianfeng_restart_v2:
+    - *RUN_FORWARD
+    - [ 'press', 'w' ]
+    - [ 'delay', 7 ]
+    - ['release', 'w']
+    - *RUN_FORWARD
+    - [ 'press_mouse', 'middle' ]
+    - [ 'release_mouse', 'middle' ]
+
 no_interrupts:
   - STEALTH_CHARGE
+  - STEALTH_DRINK
   - LIGHT_ATTACK
   - DODGE
   - IDLE
@@ -234,5 +335,6 @@ hot_list:
   - SKILL_3
   - FABAO
   - TISHEN
+  - STEALTH_DRINK
 
 

--- a/judge.py
+++ b/judge.py
@@ -91,65 +91,87 @@ class ActionJudge:
             elif b_status["skill_4"] == False and action_name == "SKILL_4":
                 reward -= 100
             elif b_status["skill_ts"] == False and action_name == "TISHEN":
-                reward -= 100
+                reward -= 200
             elif b_status["skill_fb"] == False and action_name == "FABAO":
                 reward -= 100
             elif b_status["skill_2"] == False and action_name == "STEALTH_CHARGE":
-                reward -= 100
+                reward -= 200
+            elif b_status["skill_2"] == False and action_name == "RUN_CHARGE":
+                reward += 100
 
-            if b_status["skill_1"] == True and action_name == "SKILL_1":
+            if b_status["skill_1"] == True and action_name == "DING_CHARGE":
                 reward += 100
             elif b_status["skill_2"] == True and action_name == "SKILL_2":
                 reward += 100
             elif b_status["skill_3"] == True and action_name == "SKILL_3":
-                reward += 100
+                if self.prev_action_name == "SKILL_1":
+                    reward += 100
+                reward -= 400
             elif b_status["skill_4"] == True and action_name == "SKILL_4":
-                reward += 100
+                reward -= 100
             elif b_status["skill_ts"] == True and action_name == "TISHEN":
                 reward += 100
             elif b_status["skill_fb"] == True and action_name == "FABAO":
                 reward += 100
             elif b_status["skill_2"] == True and action_name == "STEALTH_CHARGE":
+                reward += 120
+            elif b_status["skill_2"] == True and b_status["self_blood"] < 30 and action_name == "STEALTH_DRINK":
+                reward += 150
+            elif b_status["skill_2"] == True and b_status["self_blood"] > 30 and action_name == "STEALTH_DRINK":
+                reward -= 200
+
+            if self.prev_injured:
+                if action_name == "DODGE_THREE" or action_name == "DODGE_TWO":
+                    # 刚刚受伤了 这次优先闪避
+                    reward += 60
+                elif action_name == "DRINK_POTION":
+                    reward += 70
+
+            elif self.prev_action_name == "SKILL_1":
+                if action_name == "STEALTH_CHARGE" or action_name == "STEALTH_ATTACK":
+                    reward += 100
+
+            if b_status["gunshi3"] == False and action_name == "STEALTH_ATTACK":
                 reward += 100
 
             # 特殊动作规则
             if action_name == "DRINK_POTION":
-                if b_status["self_blood"] > 90:
-                    # 惩罚 满血 喝药
-                    reward -= 100
+                # if b_status["self_blood"] > 70:
+                #     # 惩罚 满血 喝药
+                #     reward -= 50
+                if b_status["self_blood"] < 60:
+                    # 奖励 血量低时 喝药WWW
+                    reward += 150
                 elif b_status["self_blood"] < 40:
                     # 奖励 血量低时 喝药
-                    reward += 50
+                    reward += 250
                 elif b_status["hulu"] < 10:
                     # 喝光了 还在喝
-                    reward -= 100
+                    reward -= 50
             elif action_name == "DODGE":
-                reward -= self.injured_index_penalty(injured, injured_cnt)
                 if not injured:
                     # 闪避 且没挨打
-                    reward += 5
+                    reward += 15
                 else:
                     # 闪避时间不对
-                    reward -= 5
-
-                if self.prev_injured:
-                    # 刚刚受伤了 这次优先闪避
-                    reward += 10
+                    reward -= 10
             elif action_name == "QIESHOU":
                 if b_status["gunshi1"] == True:
                     # 鼓励有豆的时候使用切手 有可能打出识破
-                    reward += 20
+                    reward += 15
                     reward -= self.injured_index_penalty(injured, injured_cnt)
                     if not injured:
-                        # 还没受伤 很有可能是因为识破了
-                        reward += 30
+                         # 还没受伤 很有可能是因为识破了
+                         reward += 20
+                elif b_status["gunshi1"] == False:
+                    reward -= 50
             elif action_name == "HEAVY_ATTACK":
                 if b_status["gunshi1"] == False:
                     # 没豆 打什么重击
-                    reward -= 20
+                    reward -= 50
                 elif b_status["gunshi3"] == True:
                     # 鼓励下 3豆重击
-                    reward += 20
+                    reward += 60
                 if b_status["gunshi1"] == True and self.prev_action_name == "QIESHOU":
                     reward -= self.injured_index_penalty(injured, injured_cnt)
                     if not injured:
@@ -158,23 +180,18 @@ class ActionJudge:
             elif action_name == "LIGHT_ATTACK":
                 if b_status["gunshi3"] == False:
                     # 没满三豆 鼓励可以攒棍势的攻击
-                    reward += 5
+                    reward += 25
             elif action_name == "ATTACK_DODGE":
                 if b_status["gunshi3"] == False:
                     # 没满三豆 鼓励可以攒棍势的攻击
-                    reward += 5
+                    reward += 65
             elif action_name == "FIVE_HIT_COMBO":
                 if b_status["gunshi3"] == False:
                     # 没满三豆 鼓励可以攒棍势的攻击
                     reward += 5
-            elif action_name == "SKILL_3":
-                if self.prev_action_name == "SKILL_1":
-                    # 定身后 召唤猴子 安全
-                    reward += 10
-                reward -= self.injured_index_penalty(injured, injured_cnt)
-                if injured:
-                    # 召唤猴子的时候 挨打了 时机不对
-                    reward -= 10
+            elif action_name == "RUN_CHARGE":
+                if b_status["gunshi3"] == False:
+                    reward += 70
 
             # 体能检测
             if a_status["self_energy"] < 10:


### PR DESCRIPTION
训练的是虎先锋
感觉在没有视觉识别功能的情况下，agent实际上类似一个坐在电脑前的盲人，只通过点击各种按键总结哪种按键通关成功率更高，实际上无法对boss的攻击进行识别闪避。

所以逻辑方面改成了被攻击后闪避，尝试放弃闪避所有第一下攻击，避免被连击打死，并提高喝酒奖励并添加了新的喝酒动作防止暴毙。
另外也添加了点动作，偷a和连续闪避

大佬看着改，我这里用一周目98级的数据感觉大概3小时能成功通过一次？主要还是没有视觉识别的问题。

另外就是感觉如果一开始ai训练走了弯路要及时修改，比如很喜欢开局放分身然后挨揍，因为分身奖励太高会非常依赖分身。得到奖励之后就很难修正这个动作了，我一般都是删了重来
